### PR TITLE
Detect port type using format.dsp property of individual ports.

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -290,6 +290,8 @@ mod inspector {
                                             MediaType::Audio
                                         } else if format_dsp.ends_with("midi") {
                                             MediaType::Midi
+                                        } else if format_dsp.ends_with("UMP") {
+                                            MediaType::Midi
                                         } else if format_dsp.ends_with("video") {
                                             MediaType::Video
                                         } else {
@@ -303,7 +305,9 @@ mod inspector {
                                         "Input" => {
                                             self.graph.add_input_port(id, parent, name, media_type);
                                         }
-                                        "Output" => self.graph.add_output_port(id, parent, name, media_type),
+                                        "Output" => {
+                                            self.graph.add_output_port(id, parent, name, media_type)
+                                        }
                                         _ => {}
                                     }
                                 }

--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -244,7 +244,6 @@ impl Graph {
             return;
         }
 
-        // TODO Use port params to get their media type and move this out of Nodes.
         let media_type =
             global
                 .borrow()
@@ -303,10 +302,12 @@ impl Graph {
         ))
     }
 
-    pub fn add_input_port(&mut self, id: u32, node_id: u32, name: String) {
-        let Some((node_id, media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
+    pub fn add_input_port(&mut self, id: u32, node_id: u32, name: String, media_type: Option<MediaType>) {
+        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
             return;
         };
+
+        let media_type = media_type.unwrap_or(parent_media_type);
 
         let graph_id = self.editor.graph.add_wide_input_param(
             *node_id,
@@ -321,10 +322,12 @@ impl Graph {
         self.items.insert(id, graph_id.into());
     }
 
-    pub fn add_output_port(&mut self, id: u32, node_id: u32, name: String) {
-        let Some((node_id, media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
+    pub fn add_output_port(&mut self, id: u32, node_id: u32, name: String, media_type: Option<MediaType>) {
+        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
             return;
         };
+
+        let media_type=  media_type.unwrap_or(parent_media_type);
 
         let graph_id = self
             .editor

--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -302,8 +302,15 @@ impl Graph {
         ))
     }
 
-    pub fn add_input_port(&mut self, id: u32, node_id: u32, name: String, media_type: Option<MediaType>) {
-        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
+    pub fn add_input_port(
+        &mut self,
+        id: u32,
+        node_id: u32,
+        name: String,
+        media_type: Option<MediaType>,
+    ) {
+        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id)
+        else {
             return;
         };
 
@@ -322,12 +329,19 @@ impl Graph {
         self.items.insert(id, graph_id.into());
     }
 
-    pub fn add_output_port(&mut self, id: u32, node_id: u32, name: String, media_type: Option<MediaType>) {
-        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id) else {
+    pub fn add_output_port(
+        &mut self,
+        id: u32,
+        node_id: u32,
+        name: String,
+        media_type: Option<MediaType>,
+    ) {
+        let Some((node_id, parent_media_type)) = self.port_graph_node_and_media_type(id, node_id)
+        else {
             return;
         };
 
-        let media_type=  media_type.unwrap_or(parent_media_type);
+        let media_type = media_type.unwrap_or(parent_media_type);
 
         let graph_id = self
             .editor


### PR DESCRIPTION
Addersses TODO originally at L247 of ui/graph.
The ends_with if ...else if... can probably be cached for improved performance.
Media type of the parent node is used if format.dsp isn't present in the port props,
this can occur in some video sources/sinks.

This change allows the ports of some plugins I'm using to be properly displayed, e.g.
![image](https://github.com/user-attachments/assets/b32de0e5-562a-4165-b03c-67c9f375438c)
.

