### PR TITLE
Switch from blue to white due to night mode on screen

### DIFF
--- a/src/ui/graph.rs
+++ b/src/ui/graph.rs
@@ -53,7 +53,7 @@ impl Port {
         };
 
         let color = media_type.map_or(egui::Color32::GRAY, |media_type| match *media_type {
-            MediaType::Audio => egui::Color32::BLUE,
+            MediaType::Audio => egui::Color32::WHITE,
             MediaType::Video => egui::Color32::YELLOW,
             MediaType::Application => egui::Color32::RED,
             MediaType::Binary => egui::Color32::GREEN,


### PR DESCRIPTION
Switch from blue to white due to night mode on screen that made impossible to see blue line on dark background

<img width="2613" height="1447" alt="image" src="https://github.com/user-attachments/assets/78aec72a-f3b7-4af3-9fd4-19b960b2ac5f" />
<img width="2613" height="1447" alt="image" src="https://github.com/user-attachments/assets/fd560903-1a3f-4c36-a943-5b3e5a369204" />
